### PR TITLE
feat(codepen-export): Use FlaggedComponent on the export button

### DIFF
--- a/src/DetailsView/components/export-dialog.tsx
+++ b/src/DetailsView/components/export-dialog.tsx
@@ -4,7 +4,7 @@ import { PrimaryButton } from 'office-ui-fabric-react';
 import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react';
 import { TextField } from 'office-ui-fabric-react';
 import * as React from 'react';
-import { ReportExportServiceProviderImpl } from 'report-export/report-export-service-provider-impl';
+import { ReportExportServiceProvider } from 'report-export/report-export-service-provider';
 import { ExportFormat } from 'report-export/types/report-export-service';
 import { ExportResultType } from '../../common/extension-telemetry-events';
 import { FileURLProvider } from '../../common/file-url-provider';
@@ -26,6 +26,7 @@ export interface ExportDialogProps {
 export interface ExportDialogDeps {
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
     fileURLProvider: FileURLProvider;
+    reportExportServiceProvider: ReportExportServiceProvider;
 }
 
 export const ExportDialog = NamedFC<ExportDialogProps>('ExportDialog', props => {
@@ -56,7 +57,7 @@ export const ExportDialog = NamedFC<ExportDialogProps>('ExportDialog', props => 
     };
 
     const fileURL = props.deps.fileURLProvider.provideURL([props.html], 'text/html');
-    const exportService = ReportExportServiceProviderImpl.forKey(format);
+    const exportService = props.deps.reportExportServiceProvider.forKey(format);
     const ExportForm = exportService ? exportService.exportForm : null;
 
     return (
@@ -89,7 +90,7 @@ export const ExportDialog = NamedFC<ExportDialogProps>('ExportDialog', props => 
                     splitButtonAriaLabel="Export HTML to any of these format options"
                     aria-roledescription="split button"
                     menuProps={{
-                        items: ReportExportServiceProviderImpl.all().map(service => ({
+                        items: props.deps.reportExportServiceProvider.all().map(service => ({
                             key: service.key,
                             text: service.displayName,
                             onClick: (e: React.MouseEvent<HTMLButtonElement>) => {

--- a/src/DetailsView/components/report-export-component-factory.tsx
+++ b/src/DetailsView/components/report-export-component-factory.tsx
@@ -34,6 +34,7 @@ export function getReportExportComponentForAssessment(props: CommandBarProps): J
         updatePersistedDescription: value =>
             props.deps.detailsViewActionMessageCreator.addResultDescription(value),
         getExportDescription: () => props.assessmentStoreData.resultDescription,
+        featureFlagStoreData: props.featureFlagStoreData,
     };
 
     return <ReportExportComponent {...reportExportComponentProps} />;
@@ -72,6 +73,7 @@ export function getReportExportComponentForFastPass(props: CommandBarProps): JSX
             ),
         updatePersistedDescription: () => null,
         getExportDescription: () => '',
+        featureFlagStoreData: props.featureFlagStoreData,
     };
 
     return <ReportExportComponent {...reportExportComponentProps} />;

--- a/src/DetailsView/components/report-export-component.tsx
+++ b/src/DetailsView/components/report-export-component.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import { escape } from 'lodash';
 import { ActionButton } from 'office-ui-fabric-react';
@@ -7,7 +8,6 @@ import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
 import { ExportResultType } from '../../common/extension-telemetry-events';
 import { ExportDialog, ExportDialogDeps } from './export-dialog';
-import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 
 export type ReportExportComponentDeps = {
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;

--- a/src/DetailsView/components/report-export-component.tsx
+++ b/src/DetailsView/components/report-export-component.tsx
@@ -7,6 +7,7 @@ import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
 import { ExportResultType } from '../../common/extension-telemetry-events';
 import { ExportDialog, ExportDialogDeps } from './export-dialog';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 
 export type ReportExportComponentDeps = {
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
@@ -21,6 +22,7 @@ export interface ReportExportComponentProps {
     htmlGenerator: (descriptionPlaceholder: string) => string;
     updatePersistedDescription: (value: string) => void;
     getExportDescription: () => string;
+    featureFlagStoreData: FeatureFlagStoreData;
 }
 
 export interface ReportExportComponentState {
@@ -85,6 +87,7 @@ export class ReportExportComponent extends React.Component<
                     onDescriptionChange={this.onExportDescriptionChange}
                     exportResultsType={exportResultsType}
                     onExportClick={this.generateHtml}
+                    featureFlagStoreData={this.props.featureFlagStoreData}
                 />
             </>
         );

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -19,6 +19,7 @@ import { NoContentAvailableViewRenderer } from 'DetailsView/no-content-available
 import { NullStoreActionMessageCreator } from 'electron/adapters/null-store-action-message-creator';
 import { loadTheme, setFocusVisibility } from 'office-ui-fabric-react';
 import * as ReactDOM from 'react-dom';
+import { ReportExportServiceProviderImpl } from 'report-export/report-export-service-provider-impl';
 import { AssessmentReportHtmlGenerator } from 'reports/assessment-report-html-generator';
 import { AssessmentReportModelBuilderFactory } from 'reports/assessment-report-model-builder-factory';
 import { AutomatedChecksReportSectionFactory } from 'reports/components/report-sections/automated-checks-report-section-factory';
@@ -406,6 +407,7 @@ if (isNaN(tabId) === false) {
                 issueFilingServiceProvider: IssueFilingServiceProviderImpl,
                 getGuidanceTagsFromGuidanceLinks: GetGuidanceTagsFromGuidanceLinks,
                 reportGenerator,
+                reportExportServiceProvider: ReportExportServiceProviderImpl,
                 getCardViewData: getCardViewData,
                 getPropertyConfigById: getPropertyConfiguration,
                 collapsibleControl: CardsCollapsibleControl,

--- a/src/common/feature-flags.ts
+++ b/src/common/feature-flags.ts
@@ -104,8 +104,8 @@ export function getAllFeatureFlagDetails(): FeatureFlagDetail[] {
         {
             id: FeatureFlags.exportReport,
             defaultValue: false,
-            displayableName: 'Enable more export report options',
-            displayableDescription: 'Enabling exporting reports directly to code pen',
+            displayableName: 'More export options',
+            displayableDescription: 'Enables exporting reports to external services',
             isPreviewFeature: true,
             forceDefault: false,
         },

--- a/src/common/feature-flags.ts
+++ b/src/common/feature-flags.ts
@@ -13,6 +13,8 @@ export class FeatureFlags {
     public static readonly showInstanceVisibility = 'showInstanceVisibility';
     public static readonly manualInstanceDetails = 'manualInstanceDetails';
     public static readonly debugTools = 'debugTools';
+
+    public static readonly exportReport = 'exportReport';
 }
 
 export interface FeatureFlagDetail {
@@ -97,6 +99,14 @@ export function getAllFeatureFlagDetails(): FeatureFlagDetail[] {
             displayableDescription:
                 'Click on the new icon close to the gear to open the debug tools',
             isPreviewFeature: false,
+            forceDefault: false,
+        },
+        {
+            id: FeatureFlags.exportReport,
+            defaultValue: false,
+            displayableName: 'Enable more export report options',
+            displayableDescription: 'Enabling exporting reports directly to code pen',
+            isPreviewFeature: true,
             forceDefault: false,
         },
     ];

--- a/src/report-export/report-export-service-provider-impl.ts
+++ b/src/report-export/report-export-service-provider-impl.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { ReportExportServiceProvider } from 'report-export/report-export-service-provider';
+import { CodePenReportExportService } from 'report-export/services/codepen-report-export-service';
+
+export const ReportExportServiceProviderImpl = new ReportExportServiceProvider([
+    CodePenReportExportService,
+]);

--- a/src/report-export/report-export-service-provider.ts
+++ b/src/report-export/report-export-service-provider.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { ExportFormat, ReportExportService } from 'report-export/types/report-export-service';
+
+export class ReportExportServiceProvider {
+    constructor(private readonly services: ReportExportService[]) {}
+
+    public all(): ReportExportService[] {
+        return this.services;
+    }
+
+    public forKey(key: ExportFormat): ReportExportService {
+        return this.services.find(service => service.key === key);
+    }
+}

--- a/src/report-export/services/codepen-report-export-service.tsx
+++ b/src/report-export/services/codepen-report-export-service.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 
 import {
@@ -11,18 +10,22 @@ import {
 
 const CodePenReportExportServiceKey: ExportFormat = 'codepen';
 
-const exportForm = NamedFC<ExportFormProps>(
-    'CodePenReportExportForm',
-    ({ fileName, description, html, onSubmit }) => {
-        const buttonRef = React.useRef(null);
+class ExportForm extends React.Component<ExportFormProps> {
+    private buttonRef: React.RefObject<HTMLButtonElement>;
 
-        React.useEffect(() => {
-            if (buttonRef.current) {
-                buttonRef.current.click();
-                onSubmit();
-            }
-        }, [buttonRef, onSubmit]);
+    constructor(props) {
+        super(props);
+        this.buttonRef = React.createRef();
+    }
 
+    public componentDidMount(): void {
+        if (this.buttonRef.current) {
+            this.buttonRef.current.click();
+            this.props.onSubmit();
+        }
+    }
+
+    public render(): JSX.Element {
         return (
             <form
                 action="https://codepen.io/pen/define"
@@ -35,20 +38,20 @@ const exportForm = NamedFC<ExportFormProps>(
                     name="data"
                     type="hidden"
                     value={JSON.stringify({
-                        title: fileName,
-                        description,
-                        html,
+                        title: this.props.fileName,
+                        description: this.props.description,
+                        html: this.props.html,
                         editors: '100', // collapse CSS and JS editors
                     })}
                 />
-                <button type="submit" ref={buttonRef} />
+                <button type="submit" ref={this.buttonRef} />
             </form>
         );
-    },
-);
+    }
+}
 
 export const CodePenReportExportService: ReportExportService = {
     key: CodePenReportExportServiceKey,
     displayName: 'CodePen',
-    exportForm,
+    exportForm: ExportForm,
 };

--- a/src/report-export/services/codepen-report-export-service.tsx
+++ b/src/report-export/services/codepen-report-export-service.tsx
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import * as React from 'react';
+
+import {
+    ExportFormat,
+    ExportFormProps,
+    ReportExportService,
+} from 'report-export/types/report-export-service';
+
+const CodePenReportExportServiceKey: ExportFormat = 'codepen';
+
+const exportForm = NamedFC<ExportFormProps>(
+    'CodePenReportExportForm',
+    ({ fileName, description, html, onSubmit }) => {
+        const buttonRef = React.useRef(null);
+
+        React.useEffect(() => {
+            if (buttonRef.current) {
+                buttonRef.current.click();
+                onSubmit();
+            }
+        }, [buttonRef, onSubmit]);
+
+        return (
+            <form
+                action="https://codepen.io/pen/define"
+                method="POST"
+                target="_blank"
+                rel="noopener"
+                style={{ visibility: 'hidden' }}
+            >
+                <input
+                    name="data"
+                    type="hidden"
+                    value={JSON.stringify({
+                        title: fileName,
+                        description,
+                        html,
+                        editors: '100', // collapse CSS and JS editors
+                    })}
+                />
+                <button type="submit" ref={buttonRef} />
+            </form>
+        );
+    },
+);
+
+export const CodePenReportExportService: ReportExportService = {
+    key: CodePenReportExportServiceKey,
+    displayName: 'CodePen',
+    exportForm,
+};

--- a/src/report-export/types/report-export-service.ts
+++ b/src/report-export/types/report-export-service.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { ReactFCWithDisplayName } from 'common/react/named-fc';
+
+export type ExportFormat = 'download' | 'codepen';
+
+export type ExportFormProps = ExportProps & { onSubmit: () => void };
+
+export interface ExportProps {
+    html: string;
+    fileName: string;
+    description: string;
+}
+
+export interface ReportExportService {
+    key: ExportFormat;
+    displayName: string;
+    exportForm: ReactFCWithDisplayName<ExportFormProps> | null;
+}

--- a/src/report-export/types/report-export-service.ts
+++ b/src/report-export/types/report-export-service.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ReactFCWithDisplayName } from 'common/react/named-fc';
 
 export type ExportFormat = 'download' | 'codepen';
 
@@ -15,5 +14,5 @@ export interface ExportProps {
 export interface ReportExportService {
     key: ExportFormat;
     displayName: string;
-    exportForm: ReactFCWithDisplayName<ExportFormProps> | null;
+    exportForm: React.ComponentType<ExportFormProps> | null;
 }

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dialog.test.tsx.snap
@@ -28,25 +28,42 @@ exports[`ExportDialog renders with open false 1`] = `
     value="description"
   />
   <StyledDialogFooterBase>
-    <CustomizedPrimaryButton
-      aria-roledescription="split button"
-      download="THE REPORT FILE NAME"
-      href="fake-url"
-      menuProps={
-        Object {
-          "items": Array [
-            Object {
-              "key": "codepen",
-              "onClick": [Function],
-              "text": "CodePen",
-            },
-          ],
-        }
+    <FlaggedComponent
+      disableJSXElement={
+        <CustomizedPrimaryButton
+          download="THE REPORT FILE NAME"
+          href="fake-url"
+          onClick={[Function]}
+        >
+          Export
+        </CustomizedPrimaryButton>
       }
-      onClick={[Function]}
-      split={true}
-      splitButtonAriaLabel="Export HTML to any of these format options"
-      text="Export"
+      enableJSXElement={
+        <React.Fragment>
+          <CustomizedPrimaryButton
+            aria-roledescription="split button"
+            download="THE REPORT FILE NAME"
+            href="fake-url"
+            menuProps={
+              Object {
+                "items": Array [
+                  Object {
+                    "key": "codepen",
+                    "onClick": [Function],
+                    "text": "CodePen",
+                  },
+                ],
+              }
+            }
+            onClick={[Function]}
+            split={true}
+            splitButtonAriaLabel="Export HTML to any of these format options"
+            text="Export"
+          />
+        </React.Fragment>
+      }
+      featureFlag="exportReport"
+      featureFlagStoreData={Object {}}
     />
   </StyledDialogFooterBase>
 </StyledWithResponsiveMode>
@@ -80,25 +97,42 @@ exports[`ExportDialog renders with open true 1`] = `
     value="description"
   />
   <StyledDialogFooterBase>
-    <CustomizedPrimaryButton
-      aria-roledescription="split button"
-      download="THE REPORT FILE NAME"
-      href="fake-url"
-      menuProps={
-        Object {
-          "items": Array [
-            Object {
-              "key": "codepen",
-              "onClick": [Function],
-              "text": "CodePen",
-            },
-          ],
-        }
+    <FlaggedComponent
+      disableJSXElement={
+        <CustomizedPrimaryButton
+          download="THE REPORT FILE NAME"
+          href="fake-url"
+          onClick={[Function]}
+        >
+          Export
+        </CustomizedPrimaryButton>
       }
-      onClick={[Function]}
-      split={true}
-      splitButtonAriaLabel="Export HTML to any of these format options"
-      text="Export"
+      enableJSXElement={
+        <React.Fragment>
+          <CustomizedPrimaryButton
+            aria-roledescription="split button"
+            download="THE REPORT FILE NAME"
+            href="fake-url"
+            menuProps={
+              Object {
+                "items": Array [
+                  Object {
+                    "key": "codepen",
+                    "onClick": [Function],
+                    "text": "CodePen",
+                  },
+                ],
+              }
+            }
+            onClick={[Function]}
+            split={true}
+            splitButtonAriaLabel="Export HTML to any of these format options"
+            text="Export"
+          />
+        </React.Fragment>
+      }
+      featureFlag="exportReport"
+      featureFlagStoreData={Object {}}
     />
   </StyledDialogFooterBase>
 </StyledWithResponsiveMode>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dialog.test.tsx.snap
@@ -29,12 +29,25 @@ exports[`ExportDialog renders with open false 1`] = `
   />
   <StyledDialogFooterBase>
     <CustomizedPrimaryButton
+      aria-roledescription="split button"
       download="THE REPORT FILE NAME"
       href="fake-url"
+      menuProps={
+        Object {
+          "items": Array [
+            Object {
+              "key": "codepen",
+              "onClick": [Function],
+              "text": "CodePen",
+            },
+          ],
+        }
+      }
       onClick={[Function]}
-    >
-      Export
-    </CustomizedPrimaryButton>
+      split={true}
+      splitButtonAriaLabel="Export HTML to any of these format options"
+      text="Export"
+    />
   </StyledDialogFooterBase>
 </StyledWithResponsiveMode>
 `;
@@ -68,12 +81,25 @@ exports[`ExportDialog renders with open true 1`] = `
   />
   <StyledDialogFooterBase>
     <CustomizedPrimaryButton
+      aria-roledescription="split button"
       download="THE REPORT FILE NAME"
       href="fake-url"
+      menuProps={
+        Object {
+          "items": Array [
+            Object {
+              "key": "codepen",
+              "onClick": [Function],
+              "text": "CodePen",
+            },
+          ],
+        }
+      }
       onClick={[Function]}
-    >
-      Export
-    </CustomizedPrimaryButton>
+      split={true}
+      splitButtonAriaLabel="Export HTML to any of these format options"
+      text="Export"
+    />
   </StyledDialogFooterBase>
 </StyledWithResponsiveMode>
 `;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-component-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-component-factory.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ReportExportComponentPropsFactory getReportExportComponentForAssessment
   <CustomizedActionButton iconProps={{...}} onClick={[Function]}>
     Export result
   </CustomizedActionButton>
-  <ExportDialog deps={{...}} isOpen={false} fileName=\\"\\" description=\\"\\" html=\\"\\" onClose={[Function]} onDescriptionChange={[Function]} exportResultsType=\\"Assessment\\" onExportClick={[Function]} />
+  <ExportDialog deps={{...}} isOpen={false} fileName=\\"\\" description=\\"\\" html=\\"\\" onClose={[Function]} onDescriptionChange={[Function]} exportResultsType=\\"Assessment\\" onExportClick={[Function]} featureFlagStoreData={{...}} />
 </Fragment>"
 `;
 
@@ -14,6 +14,6 @@ exports[`ReportExportComponentPropsFactory getReportExportComponentForFastPass, 
   <CustomizedActionButton iconProps={{...}} onClick={[Function]}>
     Export result
   </CustomizedActionButton>
-  <ExportDialog deps={{...}} isOpen={false} fileName=\\"\\" description=\\"\\" html=\\"\\" onClose={[Function]} onDescriptionChange={[Function]} exportResultsType=\\"AutomatedChecks\\" onExportClick={[Function]} />
+  <ExportDialog deps={{...}} isOpen={false} fileName=\\"\\" description=\\"\\" html=\\"\\" onClose={[Function]} onDescriptionChange={[Function]} exportResultsType=\\"AutomatedChecks\\" onExportClick={[Function]} featureFlagStoreData={{...}} />
 </Fragment>"
 `;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-component.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-component.test.tsx.snap
@@ -16,6 +16,11 @@ exports[`ReportExportComponentTest render 1`] = `
     deps={Object {}}
     description=""
     exportResultsType="Assessment"
+    featureFlagStoreData={
+      Object {
+        "test-feature-flag": true,
+      }
+    }
     fileName=""
     html=""
     isOpen={false}
@@ -42,6 +47,11 @@ exports[`ReportExportComponentTest user interactions click export button: dialog
     deps={Object {}}
     description="persisted description"
     exportResultsType="Assessment"
+    featureFlagStoreData={
+      Object {
+        "test-feature-flag": true,
+      }
+    }
     html=""
     isOpen={true}
     onClose={[Function]}
@@ -67,6 +77,11 @@ exports[`ReportExportComponentTest user interactions dismiss dialog: dialog shou
     deps={Object {}}
     description=""
     exportResultsType="Assessment"
+    featureFlagStoreData={
+      Object {
+        "test-feature-flag": true,
+      }
+    }
     html=""
     isOpen={false}
     onClose={[Function]}
@@ -92,6 +107,11 @@ exports[`ReportExportComponentTest user interactions edit text field: user input
     deps={Object {}}
     description="new description"
     exportResultsType="Assessment"
+    featureFlagStoreData={
+      Object {
+        "test-feature-flag": true,
+      }
+    }
     fileName=""
     html=""
     isOpen={false}

--- a/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
@@ -86,7 +86,7 @@ describe('ExportDialog', () => {
             fileProviderMock
                 .setup(provider => provider.provideURL(It.isAny(), It.isAnyString()))
                 .returns(() => 'fake-url')
-                .verifiable(Times.once());
+                .verifiable(Times.exactly(2));
             onExportClickMock.setup(getter => getter()).verifiable(Times.once());
 
             detailsViewActionMessageCreatorMock

--- a/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
@@ -5,6 +5,8 @@ import { PrimaryButton } from 'office-ui-fabric-react';
 import { Dialog } from 'office-ui-fabric-react';
 import { TextField } from 'office-ui-fabric-react';
 import * as React from 'react';
+import { ReportExportServiceProvider } from 'report-export/report-export-service-provider';
+import { CodePenReportExportService } from 'report-export/services/codepen-report-export-service';
 import { It, Mock, MockBehavior, Times } from 'typemoq';
 import { FileURLProvider } from '../../../../../common/file-url-provider';
 import { DetailsViewActionMessageCreator } from '../../../../../DetailsView/actions/details-view-action-message-creator';
@@ -15,6 +17,7 @@ describe('ExportDialog', () => {
     const onDescriptionChangeMock = Mock.ofInstance((value: string) => {});
     const detailsViewActionMessageCreatorMock = Mock.ofType(DetailsViewActionMessageCreator, MockBehavior.Strict);
     const fileProviderMock = Mock.ofType<FileURLProvider>();
+    const reportExportServiceProvider = Mock.ofType<ReportExportServiceProvider>();
     const eventStub = 'event stub' as any;
     const onExportClickMock = Mock.ofInstance(() => {});
     let props: ExportDialogProps;
@@ -25,10 +28,12 @@ describe('ExportDialog', () => {
         detailsViewActionMessageCreatorMock.reset();
         onExportClickMock.reset();
         fileProviderMock.reset();
+        reportExportServiceProvider.reset();
 
         const deps = {
             detailsViewActionMessageCreator: detailsViewActionMessageCreatorMock.object,
             fileURLProvider: fileProviderMock.object,
+            reportExportServiceProvider: reportExportServiceProvider.object,
         };
 
         props = {
@@ -53,9 +58,14 @@ describe('ExportDialog', () => {
                 .setup(provider => provider.provideURL(It.isAny(), It.isAnyString()))
                 .returns(() => 'fake-url')
                 .verifiable(Times.once());
+            reportExportServiceProvider
+                .setup(a => a.all())
+                .returns(() => [CodePenReportExportService])
+                .verifiable(Times.once());
             const wrapper = shallow(<ExportDialog {...props} />);
             expect(wrapper.getElement()).toMatchSnapshot();
 
+            reportExportServiceProvider.verifyAll();
             fileProviderMock.verifyAll();
         });
     });
@@ -67,10 +77,15 @@ describe('ExportDialog', () => {
                 .returns(() => 'fake-url')
                 .verifiable(Times.once());
             onExportClickMock.setup(getter => getter()).verifiable(Times.never());
+            reportExportServiceProvider
+                .setup(a => a.all())
+                .returns(() => [CodePenReportExportService])
+                .verifiable(Times.once());
             const wrapper = shallow(<ExportDialog {...props} />);
 
             wrapper.find(Dialog).prop('onDismiss')();
 
+            reportExportServiceProvider.verifyAll();
             fileProviderMock.verifyAll();
             onCloseMock.verifyAll();
             onDescriptionChangeMock.verifyAll();
@@ -93,10 +108,16 @@ describe('ExportDialog', () => {
                 .setup(a => a.exportResultsClicked(props.exportResultsType, props.html, eventStub))
                 .verifiable(Times.once());
 
+            reportExportServiceProvider
+                .setup(a => a.all())
+                .returns(() => [CodePenReportExportService])
+                .verifiable(Times.exactly(2));
+
             const wrapper = shallow(<ExportDialog {...props} />);
 
             wrapper.find(PrimaryButton).simulate('click', eventStub);
 
+            reportExportServiceProvider.verifyAll();
             fileProviderMock.verifyAll();
             onCloseMock.verifyAll();
             onDescriptionChangeMock.verifyAll();
@@ -112,12 +133,17 @@ describe('ExportDialog', () => {
                 .verifiable(Times.once());
             const changedDescription = 'changed-description';
             onDescriptionChangeMock.setup(handler => handler(It.isValue(changedDescription))).verifiable(Times.once());
+            reportExportServiceProvider
+                .setup(a => a.all())
+                .returns(() => [CodePenReportExportService])
+                .verifiable(Times.once());
 
             const wrapper = shallow(<ExportDialog {...props} />);
 
             const textField = wrapper.find(TextField);
             textField.simulate('change', eventStub, changedDescription);
 
+            reportExportServiceProvider.verifyAll();
             fileProviderMock.verifyAll();
             onCloseMock.verifyAll();
             onDescriptionChangeMock.verifyAll();

--- a/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
@@ -11,6 +11,8 @@ import { It, Mock, MockBehavior, Times } from 'typemoq';
 import { FileURLProvider } from '../../../../../common/file-url-provider';
 import { DetailsViewActionMessageCreator } from '../../../../../DetailsView/actions/details-view-action-message-creator';
 import { ExportDialog, ExportDialogProps } from '../../../../../DetailsView/components/export-dialog';
+import { FeatureFlags } from 'common/feature-flags';
+import { FlaggedComponent } from 'common/components/flagged-component';
 
 describe('ExportDialog', () => {
     const onCloseMock = Mock.ofInstance(() => {});
@@ -46,6 +48,7 @@ describe('ExportDialog', () => {
             onDescriptionChange: onDescriptionChangeMock.object,
             exportResultsType: 'Assessment',
             onExportClick: onExportClickMock.object,
+            featureFlagStoreData: {}, // TODO change this
         };
     });
 
@@ -69,6 +72,7 @@ describe('ExportDialog', () => {
             fileProviderMock.verifyAll();
         });
     });
+
     describe('user interaction', () => {
         it('closes the dialog onDismiss', () => {
             onCloseMock.setup(oc => oc()).verifiable(Times.once());
@@ -115,7 +119,12 @@ describe('ExportDialog', () => {
 
             const wrapper = shallow(<ExportDialog {...props} />);
 
-            wrapper.find(PrimaryButton).simulate('click', eventStub);
+            const flaggedComponent = wrapper.find(FlaggedComponent);
+
+            flaggedComponent
+                .dive()
+                .find(PrimaryButton)
+                .simulate('click', eventStub);
 
             reportExportServiceProvider.verifyAll();
             fileProviderMock.verifyAll();

--- a/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { FlaggedComponent } from 'common/components/flagged-component';
+import { FeatureFlags } from 'common/feature-flags';
 import { shallow } from 'enzyme';
 import { Dialog, PrimaryButton, TextField } from 'office-ui-fabric-react';
 import * as React from 'react';
@@ -10,7 +11,6 @@ import { It, Mock, MockBehavior, Times } from 'typemoq';
 import { FileURLProvider } from '../../../../../common/file-url-provider';
 import { DetailsViewActionMessageCreator } from '../../../../../DetailsView/actions/details-view-action-message-creator';
 import { ExportDialog, ExportDialogProps } from '../../../../../DetailsView/components/export-dialog';
-import { FeatureFlags } from 'common/feature-flags';
 
 describe('ExportDialog', () => {
     const onCloseMock = Mock.ofInstance(() => {});

--- a/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
@@ -125,6 +125,42 @@ describe('ExportDialog', () => {
             onExportClickMock.verifyAll();
         });
 
+        it('handles click on export to CodePen button', () => {
+            const unchangedDescription = 'description';
+            onDescriptionChangeMock.setup(dc => dc(It.isValue(unchangedDescription))).verifiable(Times.once());
+
+            onCloseMock.setup(oc => oc()).verifiable(Times.once());
+            fileProviderMock
+                .setup(provider => provider.provideURL(It.isAny(), It.isAnyString()))
+                .returns(() => 'fake-url')
+                .verifiable(Times.exactly(2));
+            onExportClickMock.setup(getter => getter()).verifiable(Times.once());
+
+            detailsViewActionMessageCreatorMock
+                .setup(a => a.exportResultsClicked(props.exportResultsType, props.html, eventStub))
+                .verifiable(Times.once());
+
+            reportExportServiceProvider
+                .setup(a => a.all())
+                .returns(() => [CodePenReportExportService])
+                .verifiable(Times.exactly(2));
+
+            const wrapper = shallow(<ExportDialog {...props} />);
+
+            const button = wrapper.find(PrimaryButton);
+            button
+                .props()
+                .menuProps.items.find(({ key }) => key === CodePenReportExportService.key)
+                .onClick(eventStub);
+
+            reportExportServiceProvider.verifyAll();
+            fileProviderMock.verifyAll();
+            onCloseMock.verifyAll();
+            onDescriptionChangeMock.verifyAll();
+            detailsViewActionMessageCreatorMock.verifyAll();
+            onExportClickMock.verifyAll();
+        });
+
         it('handles text changes for the description', () => {
             props.isOpen = true;
             fileProviderMock

--- a/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { FlaggedComponent } from 'common/components/flagged-component';
 import { shallow } from 'enzyme';
-import { PrimaryButton } from 'office-ui-fabric-react';
-import { Dialog } from 'office-ui-fabric-react';
-import { TextField } from 'office-ui-fabric-react';
+import { Dialog, PrimaryButton, TextField } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { ReportExportServiceProvider } from 'report-export/report-export-service-provider';
 import { CodePenReportExportService } from 'report-export/services/codepen-report-export-service';
@@ -12,7 +11,6 @@ import { FileURLProvider } from '../../../../../common/file-url-provider';
 import { DetailsViewActionMessageCreator } from '../../../../../DetailsView/actions/details-view-action-message-creator';
 import { ExportDialog, ExportDialogProps } from '../../../../../DetailsView/components/export-dialog';
 import { FeatureFlags } from 'common/feature-flags';
-import { FlaggedComponent } from 'common/components/flagged-component';
 
 describe('ExportDialog', () => {
     const onCloseMock = Mock.ofInstance(() => {});
@@ -48,7 +46,7 @@ describe('ExportDialog', () => {
             onDescriptionChange: onDescriptionChangeMock.object,
             exportResultsType: 'Assessment',
             onExportClick: onExportClickMock.object,
-            featureFlagStoreData: {}, // TODO change this
+            featureFlagStoreData: {},
         };
     });
 
@@ -134,7 +132,7 @@ describe('ExportDialog', () => {
             onExportClickMock.verifyAll();
         });
 
-        it('handles click on export to CodePen button', () => {
+        it.only('handles click on export to CodePen button', () => {
             const unchangedDescription = 'description';
             onDescriptionChangeMock.setup(dc => dc(It.isValue(unchangedDescription))).verifiable(Times.once());
 
@@ -154,10 +152,15 @@ describe('ExportDialog', () => {
                 .returns(() => [CodePenReportExportService])
                 .verifiable(Times.exactly(2));
 
+            props.featureFlagStoreData[FeatureFlags.exportReport] = true;
+
             const wrapper = shallow(<ExportDialog {...props} />);
 
-            const button = wrapper.find(PrimaryButton);
-            button
+            const flaggedComponent = wrapper.find(FlaggedComponent);
+
+            flaggedComponent
+                .dive()
+                .find(PrimaryButton)
                 .props()
                 .menuProps.items.find(({ key }) => key === CodePenReportExportService.key)
                 .onClick(eventStub);

--- a/src/tests/unit/tests/DetailsView/components/report-export-component.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-component.test.tsx
@@ -31,6 +31,9 @@ describe('ReportExportComponentTest', () => {
             htmlGenerator: htmlGeneratorMock.object,
             updatePersistedDescription: updateDescriptionMock.object,
             getExportDescription: getDescriptionMock.object,
+            featureFlagStoreData: {
+                'test-feature-flag': true,
+            },
         };
     });
 

--- a/src/tests/unit/tests/background/feature-flags.test.ts
+++ b/src/tests/unit/tests/background/feature-flags.test.ts
@@ -25,6 +25,7 @@ describe('FeatureFlagsTest', () => {
             [FeatureFlags.showInstanceVisibility]: false,
             [FeatureFlags.manualInstanceDetails]: false,
             [FeatureFlags.debugTools]: false,
+            [FeatureFlags.exportReport]: false,
         };
 
         const featureFlagValueKeys = keys(featureFlagValues);


### PR DESCRIPTION
#### Description of changes

Usually, we use feature flags to control how and when we present new feature to our users. In this case, I'm still working with the team around the UI of the export to code pen feature so it's a good idea to use the `FlaggedComponent` to present either the original export button or the new split button.

**New feature flag on the preview feature panel**
![image](https://user-images.githubusercontent.com/2837582/76991399-c25fcd00-6906-11ea-8c6a-3858d80a572b.png)

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
